### PR TITLE
Running bash scripts from everywhere in the filesystem

### DIFF
--- a/bash/run.sh
+++ b/bash/run.sh
@@ -1,9 +1,33 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-. ./config.sh
+#######################################
+# Initial setup
+#######################################
 
-SCRIPT="$1"
+PARENT_DIR="$(dirname "${BASH_SOURCE[0]}" | xargs readlink -f)"
+source "$PARENT_DIR/config.sh"
 
+#######################################
+# Input processing
+#######################################
+
+SCRIPT="$PARENT_DIR/$(basename "$1")"
 shift 1
 
+[ ! -f "$SCRIPT" ] && {
+    echo >&2 "Script not found: $1"
+    exit 1
+}
+
+#######################################
+# Invoking script
+#######################################
+
+# Cd-ing into parent directory so that the executed scripts can assume to be
+# running there
+cd "$PARENT_DIR" || exit
+
 bash "$SCRIPT" "$@"
+
+# Cd-ing back so as not to pollute the caller's environment
+cd - &> /dev/null || exit


### PR DESCRIPTION
I need to run a bash script as a systemd service. systemd doesn't understand full shell syntax, for example you can't use pipes or && and the like. This means I can't just do
```bash
cd $UTIL_DIRECTORY/bash && bash run.sh myscript.sh
```
I could have written a tiny two-liner for that specific service, or added the logic in somewhere in the bash util stuff, and I chose the latter.

The point I want to discuss is about the script executed by `run.sh`. Should it be aware that it can be run from anywhere in the filesystem, or should the working directory be handled by `run.sh`, so that the script can safely assume to be run from `util/bash`?

The former implies a slow refactoring of potentially all the scripts, but in return they would be more robust. The latter is quicker, and definitely reasonable, since we have the whole `config.sh`and `run.sh` infrastructure anyway for exactly this type of stuff.